### PR TITLE
[28기 성윤경]Fix : position absolute 제거

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -2,7 +2,6 @@
 
 .footer {
   @include flexbox(around, stretch);
-  position: absolute;
   bottom: 0;
   width: 100%;
   height: 140px;

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -2,7 +2,6 @@
 
 .footer {
   @include flexbox(around, stretch);
-  bottom: 0;
   width: 100%;
   height: 140px;
   border-top: 2px solid $black;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
-main의 contents와 하단에서 겹치게 되는 문제가 발생해서 수정했습니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. position 속성에 absolute값이 주어져 있어서 해당 속성을 제거하였습니다.
2. bottom:0  속성도 제거하였습니다.



<br />

## :: 기타 질문 및 특이 사항
- bottom:0도 같이 죽였는데도 main의 최하단에 자동으로 붙어있어서 기쁘긴 한데 왜 그러는 지 모르겠어서 궁금합니다.
- 
