### PR TITLE
[28기 성윤경] Modify: Feature/globalnav - position, link 수정

### DIFF
--- a/src/components/GlobalNav/GlobalNav.jsx
+++ b/src/components/GlobalNav/GlobalNav.jsx
@@ -23,7 +23,7 @@ function GlobalNav() {
         <Link to="/">
           <div className="logoWrapper">MOTHER TERAROSA</div>
         </Link>
-        <Link to="/shoplist/:category">
+        <Link to="/shoplist/category/0">
           <div className="categoryWrapper">SHOP</div>
         </Link>
         <div className="infoWrapper">

--- a/src/components/GlobalNav/GlobalNav.scss
+++ b/src/components/GlobalNav/GlobalNav.scss
@@ -3,7 +3,7 @@
 .globalnav {
   .commonNav {
     @include flexbox(around, center);
-    position: fixed;
+    position: relative;
     z-index: $gnb-level;
     top: 0;
     width: 100%;
@@ -113,6 +113,7 @@
 
   .miniNav {
     height: 83px;
+    position: fixed;
 
     .infoWrapper {
       .personalInfoWrapper {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 샵(쇼핑)을 클릭시 주소 오류 변경
 http://localhost:3000/:category 에서 http://localhost:3000/shoplist/category/0로 변경

2. scrollY 가 0일때 (originNav) gobalNav  position: relative로 변경, miniNav에서 position: fiexd 로 변경
index 내부 body를 직접 수정해 margin top을 주는 것 보다 네비게이션을 수정하는 쪽이 좋다는 의견을 수렴하여 수정하게 되었습니다. 


<br />


## :: 기타 질문 및 특이 사항
- 해당 기능을 통해 네비게이션 바와 페이지가 겹치는 현상이 완화되었습니다.
- miniNav의 경우 여전히 약간의 겹치는 현상이 있으나, 테라로사 사이트 자체도 동일한 현상이 있어 넘어가기로 했습니다. 
